### PR TITLE
fix: don't turn off vehicle engine off

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -128,8 +128,6 @@ local function startMove(netid, direction, pedid)
             remotepush = false
             return TriggerServerEvent('OT_pushvehicle:updateOwner', netid, direction)
         end
-        SetVehicleEngineOn(vehicle, false, true, true)
-        SetVehicleBrake(vehicle, false)
         SetVehicleForwardSpeed(vehicle, direction == 'trunk' and 1.1 or -1.1)
         if owner == playerId and seat == -1 then
             DisableControlAction(0, 34, true)


### PR DESCRIPTION
fix for #4 i don't see reason behind this to switch it off, this can end up in abusive behavior, from other player just by attempt to push your vehicle - it will turn off your engine and so on..